### PR TITLE
Improve user experience and trading interface

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,9 +69,16 @@ function SignOutButton() {
 }
 
 function Content({ liqPools }: { liqPools: LiqPool[] }) {
+  // Sort pools by current price (bridgeTokenNum / teamTokenNum) in descending order
+  const sortedPools = [...liqPools].sort((a, b) => {
+    const priceA = a.bridgeTokenNum / a.teamTokenNum;
+    const priceB = b.bridgeTokenNum / b.teamTokenNum;
+    return priceB - priceA; // Descending order (highest price first)
+  });
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
-      {liqPools.map((liqPool, index) => (
+      {sortedPools.map((liqPool, index) => (
         <LiqPoolChart key={liqPool.ticker || index} liqPool={liqPool} />
       ))}
     </div>

--- a/components/ui/chart-area-interactive.tsx
+++ b/components/ui/chart-area-interactive.tsx
@@ -53,7 +53,7 @@ export interface ChartAreaInteractiveProps {
 }
 
 export function ChartAreaInteractive({ data, teamMembers, teamName, teamImages }: ChartAreaInteractiveProps) {
-  const [timeRange, setTimeRange] = React.useState("1hr")
+  const [timeRange, setTimeRange] = React.useState("all")
   const [amount, setAmount] = React.useState(0)
   const buyTickerMutation = useMutation(api.myFunctions.buyTicker)
   const sellTickerMutation = useMutation(api.myFunctions.sellTicker)

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -16,7 +16,7 @@ export const ensureUserBalance = mutation({
     if (userBalance === null && userId !== null) {
       await ctx.db.insert("usersBalances", {
         userId: userId,
-        bridgeToken: 100,
+        bridgeToken: 1000,
       });
     }
     return { ok: true };


### PR DESCRIPTION
## Summary
- Increase initial user balance from 100 to 1000 BRDG tokens for better user experience
- Set default chart view to all-time instead of 1 hour for better market overview
- Sort liquidity pools by current price (highest first) for better discoverability

## Test plan
- [ ] Verify new users start with 1000 BRDG tokens
- [ ] Confirm charts default to all-time view
- [ ] Check that pools are sorted by price on dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)